### PR TITLE
fix unexpected EOF bug in LruReaderAt

### DIFF
--- a/reader_at.go
+++ b/reader_at.go
@@ -137,9 +137,9 @@ func (lra *LruReaderAt[T]) ReadAt(p []byte, offset int64) (int, error) {
 
 	if debug {
 		println(
-			lra, ": offset: ", offset, ", blockIndex: ", blockIndex,
-			", blockOffset: ", blockOffset, ", blockStart: ", blockStart,
-			" blockSize: ", lra.blockSize,
+			"lra:", lra, ", offset:", offset, ", blockIndex:", blockIndex,
+			", blockOffset:", blockOffset, ", blockStart:", blockStart,
+			", blockSize:", lra.blockSize, ", len(p):", len(p),
 		)
 	}
 
@@ -191,9 +191,10 @@ func (lra *LruReaderAt[T]) ReadAt(p []byte, offset int64) (int, error) {
 
 		if debug {
 			println(
-				lra, ": blockIndex: ", blockIndex, ", blockStart: ",
-				blockStart, ", nRead: ", nRead, ", readErr: ", err,
-				" readBufSize: ", len(readBuf),
+				"lra:", lra, ", blockIndex:", blockIndex, ", blockStart:",
+				blockStart, ", nRead:", nRead, ", readErr:", errString(err),
+				", readBufSize:", len(readBuf), ", totalRead:", totalRead,
+				", remainingSize:", len(remaining),
 			)
 		}
 		if nRead < 0 {
@@ -255,6 +256,9 @@ func (lra *LruReaderAt[T]) ReadAt(p []byte, offset int64) (int, error) {
 			if err == io.EOF {
 				lra.eofIndex = blockIndex
 				lra.cache.Add(blockIndex, readBuf[:nRead])
+				if n < (nRead - blockOffset) {
+					err = nil
+				}
 			} else if nRead == lra.blockSize {
 				lra.cache.Add(blockIndex, readBuf)
 			} else {
@@ -350,4 +354,11 @@ func lruHash(key uint64) uint32 {
 	h = (h ^ uint32(b[6])) * prime32
 	h = (h ^ uint32(b[7])) * prime32
 	return h
+}
+
+func errString(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+	return err.Error()
 }

--- a/reader_at_test.go
+++ b/reader_at_test.go
@@ -199,6 +199,20 @@ func TestLruReaderAt(t *testing.T) {
 				{sz: 15, off: 90, el: errIfEofNil, er: errIfEofNil},
 			},
 		},
+		{
+			name: "no eof when read more to cache",
+			readerFunc: func() io.ReaderAt {
+				autoGrow := false
+				sb := xio.NewStorageBuffer(make([]byte, 1000), autoGrow)
+				mustRandFillWriterAt(sb, sb.Len())
+				return sb
+			},
+			blockSize: 110,
+			cacheSize: 3,
+			reads: []readersAtCase{
+				{sz: 49, off: 950, el: nil, er: nil},
+			},
+		},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
Fix unexpected EOF when last read block is not fully consumed in LruReaderAt.ReadAt.