### PR TITLE
refactor LruReaderAt error handling

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -39,7 +39,7 @@ func (e *ReadersDataCmpError) Unwrap() error {
 // data in the chunks. If the data read from the readers is not equal, it
 // returns an error with the data read from the readers. The error is of type
 // *ReadersDataCmpError.
-func CmpReadersData[T1, T2 io.Reader](left T1, right T2) error {
+func CmpReadersData[L, R io.Reader](left L, right R) error {
 	return CmpReadersDataWithBuffer(left, right, nil)
 }
 
@@ -47,7 +47,7 @@ func CmpReadersData[T1, T2 io.Reader](left T1, right T2) error {
 // to use for reading data from the readers. If the buffer is not provided, a
 // new buffer of size 64KB is used. Given buffer is split into two halves and
 // used for reading data from the readers.
-func CmpReadersDataWithBuffer[T1, T2 io.Reader](left T1, right T2, buffer []byte) error {
+func CmpReadersDataWithBuffer[L, R io.Reader](left L, right R, buffer []byte) error {
 	if len(buffer) > 0 && len(buffer)%2 != 0 {
 		buffer = buffer[:len(buffer)-1]
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -183,16 +183,15 @@ func ExampleLruReaderAt_simple() {
 }
 
 func ExampleCmpReadersData() {
-	b := make([]byte, 0, 1000*1000)
-	buf := bytes.NewBuffer(b)
+	b := make([]byte, 1000*1000)
 
-	_, err := io.CopyN(buf, rand.Reader, int64(cap(b)))
+	_, err := xio.ReadFill(rand.Reader, b)
 	if err != nil {
 		panic(err)
 	}
 
-	r1 := bytes.NewReader(buf.Bytes())
-	r2 := bufio.NewReader(bytes.NewReader(buf.Bytes()))
+	r1 := bytes.NewReader(b)
+	r2 := bufio.NewReader(bytes.NewReader(b))
 
 	err = xio.CmpReadersData(r1, r2)
 	if err != nil {

--- a/reader_at_test.go
+++ b/reader_at_test.go
@@ -56,7 +56,8 @@ func TestLruReaderAt(t *testing.T) {
 				{sz: 10, off: 60},
 				{sz: 10, off: 70},
 				{sz: 10, off: 80},
-				{sz: 10, off: 90, er: io.EOF},
+				{sz: 10, off: 90},
+				{sz: 10, off: 90},
 				{sz: 10, off: 100, el: io.EOF, er: io.EOF},
 				{sz: 10, off: 101, el: io.EOF, er: io.EOF},
 			},
@@ -113,7 +114,8 @@ func TestLruReaderAt(t *testing.T) {
 				{sz: 256, off: 0},
 				{sz: 256, off: 256},
 				{sz: 256, off: 512},
-				{sz: 256, off: 768, er: io.EOF},
+				{sz: 256, off: 768},
+				{sz: 256, off: 768},
 				{sz: 256, off: 1024, el: io.EOF, er: io.EOF},
 				{sz: 256, off: 1025, el: io.EOF, er: io.EOF},
 			},
@@ -398,7 +400,7 @@ func TestLruReaderAt_edge_cases(t *testing.T) {
 		buf := make([]byte, 800)
 		n, err := lra.ReadAt(buf, 0)
 		require.Equal(t, r.Len(), n)
-		require.Equal(t, io.EOF, err)
+		require.Nil(t, err)
 
 		n, err = lra.ReadAt(buf[:100], 500)
 		require.Equal(t, 100, n)

--- a/xio.go
+++ b/xio.go
@@ -13,11 +13,12 @@ const debug = false
 const maxConsecutiveEmptyReads = 100
 
 // ErrNoSpaceLeft is returned when there is no space left in the underlying storage.
-var ErrNoSpaceLeft = errors.New("no space left")
+var ErrNoSpaceLeft = errors.New("xio: no space left")
 
 // ErrShortRead is returned when the read operation could not read the requested
-// number of bytes for the ReadAt operations.
-var ErrShortRead = errors.New("short read")
+// number of bytes for the ReadAt operations and the underlying reader did not
+// return io.EOF or other error.
+var ErrShortRead = errors.New("xio: short read")
 
 // Storage is the interface that wraps the basic io.ReaderAt and io.WriterAt interfaces.
 type Storage interface {


### PR DESCRIPTION
- no EOF is returned when exact bytes is read from LruReaderAt
- minor type parameter name change for readibility
- minor example refactoring